### PR TITLE
Fix IE11 bug on slick carousel

### DIFF
--- a/_grow/dist/js/main.min.js
+++ b/_grow/dist/js/main.min.js
@@ -1,8 +1,8 @@
 // Slick carousel module
 //
 var carousel = function() {
-  var slickEls = document.querySelectorAll('.slick');
-  slickEls.forEach(function(element) {
+  var $slickCarousels = $('.slick');
+  $.each($slickCarousels, function(index, element) {
     var arrows = element.hasAttribute("data-arrows");
     var dots = element.hasAttribute("data-dots");
     var carouselName = element.getAttribute("data-carousel-name");
@@ -12,6 +12,7 @@ var carousel = function() {
       dots: dots,
       draggable: true,
       accessibility: true,
+      zIndex: true,
       responsive: [{
         breakpoint: 560,
         settings: {

--- a/_grow/source/js/carousel.js
+++ b/_grow/source/js/carousel.js
@@ -1,8 +1,8 @@
 // Slick carousel module
 //
 var carousel = function() {
-  var slickEls = document.querySelectorAll('.slick');
-  slickEls.forEach(function(element) {
+  var $slickCarousels = $('.slick');
+  $.each($slickCarousels, function(index, element) {
     var arrows = element.hasAttribute("data-arrows");
     var dots = element.hasAttribute("data-dots");
     var carouselName = element.getAttribute("data-carousel-name");
@@ -12,6 +12,7 @@ var carousel = function() {
       dots: dots,
       draggable: true,
       accessibility: true,
+      zIndex: true,
       responsive: [{
         breakpoint: 560,
         settings: {


### PR DESCRIPTION
IE doesn't recognize "forEach" so I updated it to jQuery's $.each method